### PR TITLE
Suggested update to fix spelling mistake and links

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -70,10 +70,10 @@ mlp:add( nn.Tanh() ) -- some hyperbolic tangent transfer function
 mlp:add( nn.Linear(25, 1) ) -- 1 output
 ```
 
-Of course, `Sequential` and `Concat` can contains other
+Of course, `Sequential` and `Concat` can contain other
 `Sequential` or `Concat`, allowing you to try the craziest neural
-networks you ever dreamt of! See the [[#nn.Modules|complete list of
-available modules]].
+networks you ever dreamt of! See the [complete list of available 
+modules](module.md#nn.Modules).
 
 <a name="nn.overview.training"/>
 ### Training a neural network ###


### PR DESCRIPTION
This is merely a cosmetic change. A minor spelling mistake and an update
to text formatting. It seems to me that the 'complete list of available modules' 
was intended to point to nn.Modules - that's what I've done here.
